### PR TITLE
Expand Glyphsmith encounters and progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# Fall-season
-Fall style game
+# Glyphsmith: Fall-season Math Ritual
+
+Glyphsmith is a browser-based, math-driven arcade experience. Speak in numbers and operators to cast spells that collapse into the exact target value, while steadying a sequence of increasingly unstable encounters. Build streaks, honor sigil conditions for heavy bonuses, and feel the pressure as the clock shrinks.
+
+## Play the game
+
+1. Open `index.html` in your browser.
+2. Tap **Start Casting** to begin the ritual.
+3. Use the on-screen glyph keyboard (or your physical keyboard) to compose an expression that evaluates exactly to the target number.
+4. Honor the highlighted **Sigil Condition** for each challenge to earn a surge of essence and deal heavy stability damage.
+5. Hit **Cast** or press Enter to submit.
+6. Use every digit in the glyph bank to trigger combo multipliers. Longer, more complex expressions also boost rewards.
+7. Each successful cast weakens the current encounter and raises your level, squeezing the timer. Miss or mistype and your streak collapses.
+8. Spend artifacts — **Stabilize Flow** to reclaim time and **Reforge Glyphs** to redraw a challenge — when the rift rewards them.
+
+The layout is responsive and the primary workspace maintains a minimum 50% of the viewport height, keeping the play area visible even when mobile keyboards claim half the screen.
+
+## Features
+
+- **Stage-based encounters** – Stabilize escalating foes, each with distinct lore, scaling health, and artifact rewards.
+- **Dynamic sigil conditions** – Optional objectives such as using parentheses, subtraction, or power glyphs that grant bonus essence and extra damage when satisfied.
+- **Artifacts** – Earn and deploy Stabilize Flow (adds breathing room to the timer) and Reforge Glyphs (refreshes the current challenge without penalty).
+- **Procedural spellcraft** – Each round rolls a fresh glyph bank and target, with adaptive difficulty tied to your level and stage.
+- **Spell chronicle** – A running log of successes, miscasts, timeouts, and encounter events to study your ritual history.
+- **Glyph awareness** – Digits highlight as they are used, encouraging clever reuse of the available symbols.
+- **Adaptive timer & combo scoring** – Complex expressions and complete glyph usage amplify rewards as the window to respond narrows.
+- **Keyboard & touch support** – Tap the glyph keyboard or type directly.
+
+## Tech stack
+
+- Vanilla HTML, CSS, and JavaScript.
+- Responsive layout tailored for desktop and mobile play.
+
+Happy casting!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Glyphsmith: Math Tongue</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Kanit:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <div class="branding">
+          <h1>Glyphsmith</h1>
+          <p>Speak in the language of math to weave reality.</p>
+        </div>
+        <button class="button button--primary" id="startButton">Start Casting</button>
+      </header>
+
+      <section class="status" aria-live="polite">
+        <div class="status__item">
+          <span class="status__label">Score</span>
+          <span class="status__value" id="score">0</span>
+        </div>
+        <div class="status__item">
+          <span class="status__label">Streak</span>
+          <span class="status__value" id="streak">0</span>
+        </div>
+        <div class="status__item">
+          <span class="status__label">Level</span>
+          <span class="status__value" id="level">1</span>
+        </div>
+        <div class="status__item">
+          <span class="status__label">Stage</span>
+          <span class="status__value" id="stage">1</span>
+        </div>
+        <div class="status__item">
+          <span class="status__label">Time</span>
+          <span class="status__value" id="timer">--</span>
+        </div>
+      </section>
+
+      <section class="battlefield" aria-live="polite">
+        <div class="challenge">
+          <div class="challenge__prompt">Target Glyph</div>
+          <div class="challenge__value" id="target">Press start</div>
+        </div>
+        <div class="challenge challenge--glyphs">
+          <div class="challenge__prompt">Glyph Bank</div>
+          <ul class="glyphs" id="glyphBank" aria-live="polite"></ul>
+        </div>
+        <div class="challenge challenge--meter">
+          <div class="meter">
+            <div class="meter__fill" id="timeMeter"></div>
+          </div>
+          <p class="meter__label">
+            Craft an incantation using the glyphs. Bonus for using all digits.
+          </p>
+        </div>
+      </section>
+
+      <section class="encounter" aria-live="polite">
+        <div class="encounter__header">
+          <h2 id="encounterTitle">Dormant Rift</h2>
+          <span class="encounter__stage">Stage <span id="encounterStage">1</span></span>
+        </div>
+        <p class="encounter__narrative" id="encounterLore">
+          Stabilize the realm by matching the target glyphs.
+        </p>
+        <div class="encounter__health">
+          <div class="encounter__bar">
+            <div class="encounter__fill" id="encounterHealth"></div>
+          </div>
+          <span class="encounter__hp" id="encounterHP">-- / -- stability</span>
+        </div>
+        <div class="encounter__objective">
+          <h3>Sigil Condition</h3>
+          <p id="sigilCondition">Complete a cast to reveal the realm.</p>
+          <p class="encounter__bonus" id="sigilReward">Bonus ready.</p>
+        </div>
+      </section>
+
+      <section class="workspace">
+        <div class="workspace__display" role="status" aria-live="polite">
+          <span id="expression">&nbsp;</span>
+        </div>
+        <div class="keyboard" role="group" aria-label="Glyph keyboard">
+          <div class="keyboard__row" id="digitKeys"></div>
+          <div class="keyboard__row" id="operatorKeys"></div>
+          <div class="keyboard__row keyboard__row--controls">
+            <button class="button" data-action="undo">Undo</button>
+            <button class="button" data-action="clear">Clear</button>
+            <button class="button button--primary" data-action="cast">Cast</button>
+          </div>
+        </div>
+        <div class="artifacts" role="group" aria-label="Artifacts">
+          <button class="button button--ghost" data-artifact="stabilize" id="stabilizeButton">
+            Stabilize Flow (<span id="stabilizeCount">0</span>)
+          </button>
+          <button class="button button--ghost" data-artifact="reshuffle" id="reshuffleButton">
+            Reforge Glyphs (<span id="reshuffleCount">0</span>)
+          </button>
+        </div>
+        <p class="workspace__hint" id="hint"></p>
+      </section>
+
+      <section class="chronicle" aria-live="polite">
+        <h2>Spell Chronicle</h2>
+        <ul class="chronicle__log" id="historyLog"></ul>
+      </section>
+
+      <section class="codex">
+        <h2>Codex of Play</h2>
+        <ol>
+          <li>Tap <strong>Start Casting</strong> to awaken a new challenge.</li>
+          <li>
+            Use the glyph keyboard or your own keys to compose an expression that
+            evaluates exactly to the <strong>Target Glyph</strong>.
+          </li>
+          <li>
+            You may only use digits from the <strong>Glyph Bank</strong>, but you
+            can reuse them as needed. Using every digit at least once grants a
+            combo multiplier.
+          </li>
+          <li>
+            Each correct cast increases your streak, score, and compresses the
+            time window.
+          </li>
+          <li>
+            Trip up, and the streak resets while the realm destabilizes.
+          </li>
+        </ol>
+        <p class="codex__tip">
+          Tip: Parentheses and exponents (^) make potent incantations.
+        </p>
+      </section>
+    </main>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,800 @@
+const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+const operators = ['+', '-', '×', '÷', '^', '(', ')'];
+
+const encounterDeck = [
+  {
+    name: 'Fractal Wisp',
+    lore: 'A rogue shimmer of numbers coils around the arena, warping simple sums into fractal spirals.',
+    baseHealth: 120,
+    rewards: { stabilize: 1 }
+  },
+  {
+    name: 'Vector Hydra',
+    lore: 'Each successful cast severs one of the hydra\'s vector heads before it can multiply unchecked.',
+    baseHealth: 150,
+    rewards: { reshuffle: 1 }
+  },
+  {
+    name: 'Tempo Apparatus',
+    lore: 'A clockwork obelisk that accelerates time whenever your focus slips.',
+    baseHealth: 170,
+    rewards: { stabilize: 1, reshuffle: 1 }
+  },
+  {
+    name: 'Prime Sovereign',
+    lore: 'The sovereign demands only immaculate results — primes resonate with its crystalline core.',
+    baseHealth: 200,
+    rewards: { stabilize: 2 }
+  }
+];
+
+const sigilConditions = [
+  {
+    id: 'threeOperators',
+    text: 'Wield at least three operators in your spell.',
+    check: (expression) => (expression.match(/[+\-×÷^]/g) || []).length >= 3
+  },
+  {
+    id: 'evenResult',
+    text: 'Stabilize the rift with an even result.',
+    check: (_, result) => Math.abs(result % 2) < 1e-9
+  },
+  {
+    id: 'parentheses',
+    text: 'Bind the energies with at least one set of parentheses.',
+    check: (expression) => expression.includes('(') && expression.includes(')')
+  },
+  {
+    id: 'powerGlyph',
+    text: 'Invoke the power glyph ^ somewhere in the incantation.',
+    check: (expression) => expression.includes('^')
+  },
+  {
+    id: 'highestGlyph',
+    text: 'Channel the highest glyph from the bank at least once.',
+    check: (expression, _result, context) => {
+      const highest = context.glyphs.reduce((max, glyph) => Math.max(max, Number(glyph)), 0);
+      return expression.includes(String(highest));
+    }
+  },
+  {
+    id: 'subtractive',
+    text: 'Temper the spell with a subtraction.',
+    check: (expression) => expression.includes('-')
+  },
+  {
+    id: 'lengthy',
+    text: 'Compose a lengthy chant with at least eight glyphs.',
+    check: (expression) => expression.replace(/\s/g, '').length >= 8
+  }
+];
+
+const startButton = document.getElementById('startButton');
+const scoreEl = document.getElementById('score');
+const streakEl = document.getElementById('streak');
+const levelEl = document.getElementById('level');
+const stageEl = document.getElementById('stage');
+const timerEl = document.getElementById('timer');
+const timeMeter = document.getElementById('timeMeter');
+const targetEl = document.getElementById('target');
+const glyphBankEl = document.getElementById('glyphBank');
+const expressionEl = document.getElementById('expression');
+const digitKeysRow = document.getElementById('digitKeys');
+const operatorKeysRow = document.getElementById('operatorKeys');
+const hintEl = document.getElementById('hint');
+const encounterStageEl = document.getElementById('encounterStage');
+const encounterTitleEl = document.getElementById('encounterTitle');
+const encounterLoreEl = document.getElementById('encounterLore');
+const encounterHealthFill = document.getElementById('encounterHealth');
+const encounterHpEl = document.getElementById('encounterHP');
+const sigilConditionEl = document.getElementById('sigilCondition');
+const sigilRewardEl = document.getElementById('sigilReward');
+const historyLogEl = document.getElementById('historyLog');
+const stabilizeButton = document.getElementById('stabilizeButton');
+const reshuffleButton = document.getElementById('reshuffleButton');
+const stabilizeCountEl = document.getElementById('stabilizeCount');
+const reshuffleCountEl = document.getElementById('reshuffleCount');
+
+let gameState = {
+  active: false,
+  score: 0,
+  streak: 0,
+  level: 1,
+  stage: 1,
+  timer: null,
+  timeRemaining: 0,
+  baseTime: 35,
+  target: null,
+  glyphs: [],
+  expression: '',
+  digitsUsed: new Set(),
+  roundCount: 0,
+  encounter: null,
+  sigilCondition: null,
+  sigilBonus: 0,
+  artifacts: {
+    stabilize: 0,
+    reshuffle: 0
+  },
+  history: []
+};
+
+const keyboardButtons = new Map();
+
+function initKeyboard() {
+  digits.forEach((d) => {
+    const button = document.createElement('button');
+    button.className = 'button';
+    button.textContent = d;
+    button.dataset.value = d;
+    digitKeysRow.appendChild(button);
+    keyboardButtons.set(d, button);
+  });
+
+  operators.forEach((op) => {
+    const button = document.createElement('button');
+    button.className = 'button';
+    button.textContent = op;
+    button.dataset.value = op;
+    operatorKeysRow.appendChild(button);
+    keyboardButtons.set(op, button);
+  });
+
+  digitKeysRow.addEventListener('click', onKeyboardClick);
+  operatorKeysRow.addEventListener('click', onKeyboardClick);
+  document
+    .querySelector('.keyboard__row--controls')
+    .addEventListener('click', onControlClick);
+
+  document.addEventListener('keydown', onKeyDown);
+}
+
+function initArtifacts() {
+  stabilizeButton.addEventListener('click', () => useArtifact('stabilize'));
+  reshuffleButton.addEventListener('click', () => useArtifact('reshuffle'));
+  updateArtifacts();
+}
+
+function onKeyboardClick(event) {
+  if (event.target instanceof HTMLButtonElement) {
+    const value = event.target.dataset.value;
+    if (value) appendToExpression(value);
+  }
+}
+
+function onControlClick(event) {
+  if (!(event.target instanceof HTMLButtonElement)) return;
+  const action = event.target.dataset.action;
+  if (action === 'undo') {
+    undoExpression();
+  } else if (action === 'clear') {
+    clearExpression();
+  } else if (action === 'cast') {
+    castExpression();
+  }
+}
+
+function onKeyDown(event) {
+  if (!gameState.active) return;
+  const key = event.key;
+  if (digits.includes(key)) {
+    appendToExpression(key);
+  } else if (['+', '-', '*', '/', '^', '(', ')'].includes(key)) {
+    appendToExpression(key === '*' ? '×' : key === '/' ? '÷' : key);
+  } else if (key === 'Backspace') {
+    undoExpression();
+    event.preventDefault();
+  } else if (key === 'Enter') {
+    castExpression();
+    event.preventDefault();
+  }
+}
+
+function appendToExpression(value) {
+  if (!gameState.active) return;
+  gameState.expression += value;
+  expressionEl.textContent = gameState.expression;
+  if (digits.includes(value)) {
+    gameState.digitsUsed.add(value);
+    updateGlyphUsage();
+  }
+}
+
+function undoExpression() {
+  if (!gameState.active || gameState.expression.length === 0) return;
+  const removed = gameState.expression.slice(-1);
+  gameState.expression = gameState.expression.slice(0, -1);
+  expressionEl.textContent = gameState.expression || '\u00A0';
+  if (digits.includes(removed)) {
+    recalculateDigitsUsed();
+  }
+}
+
+function recalculateDigitsUsed() {
+  gameState.digitsUsed.clear();
+  for (const char of gameState.expression) {
+    if (digits.includes(char)) {
+      gameState.digitsUsed.add(char);
+    }
+  }
+  updateGlyphUsage();
+}
+
+function clearExpression() {
+  if (!gameState.active) return;
+  gameState.expression = '';
+  gameState.digitsUsed.clear();
+  expressionEl.textContent = '\u00A0';
+  updateGlyphUsage();
+}
+
+function castExpression() {
+  if (!gameState.active || !gameState.expression.trim()) {
+    setHint('Craft an expression before casting.');
+    return;
+  }
+
+  const outcome = evaluateExpression(gameState.expression);
+  if (!outcome.valid) {
+    setHint(outcome.message);
+    logSpell({
+      success: false,
+      expression: gameState.expression,
+      result: null,
+      message: outcome.message
+    });
+    penalize(false, {
+      skipLog: true,
+      message: outcome.message,
+      expression: gameState.expression
+    });
+    return;
+  }
+
+  const usesAllowedDigits = [...gameState.expression].every((char) => {
+    return !digits.includes(char) || gameState.glyphs.includes(char);
+  });
+
+  if (!usesAllowedDigits) {
+    const message = 'Only digits from the glyph bank may be summoned.';
+    setHint(message);
+    logSpell({
+      success: false,
+      expression: gameState.expression,
+      result: outcome.value,
+      message: 'Illegal glyph usage.'
+    });
+    penalize(false, {
+      skipLog: true,
+      message,
+      expression: gameState.expression,
+      result: outcome.value
+    });
+    return;
+  }
+
+  const result = outcome.value;
+  if (Math.abs(result - gameState.target) < 1e-9) {
+    const sigilComplete = checkSigilCondition(gameState.expression, result);
+    reward(outcome, { sigilComplete });
+  } else {
+    const message = `The spell resolved to ${formatNumber(result)}, not ${gameState.target}.`;
+    setHint(message);
+    logSpell({
+      success: false,
+      expression: gameState.expression,
+      result,
+      message
+    });
+    penalize(true, {
+      skipLog: true,
+      message,
+      expression: gameState.expression,
+      result
+    });
+  }
+}
+
+function evaluateExpression(rawExpression) {
+  const sanitized = rawExpression
+    .replace(/[×]/g, '*')
+    .replace(/[÷]/g, '/')
+    .replace(/\^/g, '**');
+
+  if (/[^0-9+\-*/()\s*.]/.test(sanitized)) {
+    return { valid: false, message: 'Unknown glyph detected.' };
+  }
+
+  try {
+    const fn = new Function(`return (${sanitized})`);
+    const value = fn();
+    if (!Number.isFinite(value)) {
+      return { valid: false, message: 'The incantation collapsed into infinity.' };
+    }
+    return { valid: true, value };
+  } catch (error) {
+    return { valid: false, message: 'The structure of the spell is unstable.' };
+  }
+}
+
+function formatNumber(value) {
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+  return Number.parseFloat(value.toFixed(2)).toString();
+}
+
+function checkSigilCondition(expression, result) {
+  if (!gameState.sigilCondition) {
+    return false;
+  }
+
+  try {
+    return gameState.sigilCondition.check(expression, result, {
+      glyphs: gameState.glyphs
+    });
+  } catch (error) {
+    return false;
+  }
+}
+
+function reward(outcome, extras = {}) {
+  const { sigilComplete = false } = extras;
+  const allDigitsUsed = gameState.glyphs.every((glyph) =>
+    gameState.digitsUsed.has(glyph)
+  );
+  const base = 140 + gameState.level * 22;
+  const comboMultiplier = allDigitsUsed ? 1.6 + gameState.level * 0.05 : 1;
+  const complexityMultiplier = Math.min(3, 1 + gameState.expression.length / 8);
+  const gain = Math.round(base * comboMultiplier * complexityMultiplier);
+  const sigilBonus = sigilComplete ? gameState.sigilBonus : 0;
+  const totalGain = gain + sigilBonus;
+
+  gameState.score += totalGain;
+  gameState.streak += 1;
+  if (gameState.streak % 3 === 0) {
+    gameState.level += 1;
+  }
+
+  const bonusText = [];
+  if (allDigitsUsed) {
+    bonusText.push('All glyphs ×' + comboMultiplier.toFixed(2));
+  }
+  if (complexityMultiplier > 1) {
+    bonusText.push('Complexity boost');
+  }
+  if (sigilComplete) {
+    bonusText.push('Sigil honored');
+    sigilRewardEl.textContent = 'Sigil honored! Bonus delivered.';
+  }
+
+  const summary = `Spell lands! +${totalGain} essence${
+    bonusText.length ? ' (' + bonusText.join(', ') + ')' : ''
+  }.`;
+  setHint(summary);
+  logSpell({
+    success: true,
+    expression: gameState.expression,
+    result: outcome.value,
+    message: summary,
+    tags: bonusText
+  });
+
+  flashMeter('success');
+  updateStatus();
+  updateArtifacts();
+  const encounterResolved = applyEncounterDamage(totalGain, { sigilComplete });
+  if (!encounterResolved) {
+    nextChallenge();
+  }
+}
+
+function applyEncounterDamage(scoreGain, { sigilComplete }) {
+  if (!gameState.encounter) {
+    return false;
+  }
+
+  const baseDamage = Math.max(12, Math.round(scoreGain / 4));
+  const sigilDamage = sigilComplete ? Math.round(gameState.sigilBonus / 3) : 0;
+  const totalDamage = baseDamage + sigilDamage;
+  gameState.encounter.health = Math.max(
+    0,
+    gameState.encounter.health - totalDamage
+  );
+  updateEncounter();
+
+  if (gameState.encounter.health <= 0) {
+    handleEncounterVictory();
+    return true;
+  }
+  return false;
+}
+
+function handleEncounterVictory() {
+  const defeated = gameState.encounter;
+  logEncounterEvent(`${defeated.name} stabilized. Spoils resonate!`);
+  grantArtifacts(defeated.rewards);
+  gameState.stage += 1;
+  gameState.roundCount = 0;
+  const acceleration = Math.min(12, Math.floor(gameState.stage / 2));
+  gameState.baseTime = Math.max(20, 35 - acceleration);
+  setupEncounter();
+  nextChallenge();
+  setHint(`The realm steadies. Prepare for Stage ${gameState.stage}.`);
+}
+
+function setupEncounter() {
+  const index = (gameState.stage - 1) % encounterDeck.length;
+  const cycle = Math.floor((gameState.stage - 1) / encounterDeck.length);
+  const template = encounterDeck[index];
+  const scale = 1 + cycle * 0.4 + (gameState.stage - 1) * 0.08;
+  const maxHealth = Math.max(80, Math.round(template.baseHealth * scale));
+  gameState.encounter = {
+    ...template,
+    health: maxHealth,
+    maxHealth
+  };
+  encounterTitleEl.textContent = template.name;
+  encounterLoreEl.textContent = template.lore;
+  encounterStageEl.textContent = gameState.stage;
+  updateEncounter();
+}
+
+function updateEncounter() {
+  if (!gameState.encounter) return;
+  const ratio = Math.max(
+    0,
+    gameState.encounter.health / gameState.encounter.maxHealth
+  );
+  encounterHealthFill.style.transform = `scaleX(${ratio})`;
+  encounterHpEl.textContent = `${gameState.encounter.health} / ${gameState.encounter.maxHealth} stability`;
+  stageEl.textContent = gameState.stage;
+  encounterStageEl.textContent = gameState.stage;
+}
+
+function assignSigilCondition() {
+  if (!gameState.active) {
+    sigilConditionEl.textContent = 'Complete a cast to reveal the realm.';
+    sigilRewardEl.textContent = 'Bonus ready.';
+    return;
+  }
+  const condition =
+    sigilConditions[Math.floor(Math.random() * sigilConditions.length)];
+  gameState.sigilCondition = condition;
+  gameState.sigilBonus = Math.round(120 + gameState.level * 25 + gameState.stage * 12);
+  sigilConditionEl.textContent = condition.text;
+  sigilRewardEl.textContent = `Bonus: +${gameState.sigilBonus} essence & heavy stability damage.`;
+}
+
+function grantArtifacts(rewards = {}) {
+  if (!rewards) return;
+  if (rewards.stabilize) {
+    gameState.artifacts.stabilize += rewards.stabilize;
+  }
+  if (rewards.reshuffle) {
+    gameState.artifacts.reshuffle += rewards.reshuffle;
+  }
+  updateArtifacts();
+}
+
+function updateArtifacts() {
+  stabilizeCountEl.textContent = gameState.artifacts.stabilize;
+  reshuffleCountEl.textContent = gameState.artifacts.reshuffle;
+  const canStabilize = gameState.active && gameState.artifacts.stabilize > 0;
+  const canReshuffle = gameState.active && gameState.artifacts.reshuffle > 0;
+  stabilizeButton.disabled = !canStabilize;
+  reshuffleButton.disabled = !canReshuffle;
+}
+
+function useArtifact(type) {
+  if (!gameState.active) return;
+  if (!gameState.artifacts[type] || gameState.artifacts[type] <= 0) return;
+
+  if (type === 'stabilize') {
+    gameState.artifacts.stabilize -= 1;
+    gameState.timeRemaining = Math.min(
+      gameState.currentTimeLimit,
+      gameState.timeRemaining + Math.max(5, Math.round(gameState.currentTimeLimit * 0.35))
+    );
+    updateTimerDisplay();
+    setHint('Time stabilizes, granting you a breath.');
+    logEncounterEvent('Used Stabilize Flow to reclaim a few precious moments.');
+    updateArtifacts();
+  } else if (type === 'reshuffle') {
+    gameState.artifacts.reshuffle -= 1;
+    updateArtifacts();
+    gameState.roundCount = Math.max(0, gameState.roundCount - 1);
+    nextChallenge(false);
+    setHint('You reforge the glyphs into a fresh arrangement.');
+    logEncounterEvent('Reforged the glyph bank for a new opportunity.');
+    return;
+  }
+}
+
+function addHistoryEntry(entry) {
+  gameState.history.unshift(entry);
+  gameState.history = gameState.history.slice(0, 8);
+  updateHistory();
+}
+
+function logSpell({ expression, result, success, message, tags = [] }) {
+  if (!historyLogEl) return;
+  addHistoryEntry({
+    type: 'spell',
+    expression: expression || '—',
+    result:
+      typeof result === 'number' && Number.isFinite(result)
+        ? formatNumber(result)
+        : result,
+    success,
+    message,
+    tags,
+    timestamp: Date.now()
+  });
+}
+
+function logEncounterEvent(message) {
+  if (!historyLogEl) return;
+  addHistoryEntry({
+    type: 'event',
+    success: true,
+    message,
+    timestamp: Date.now()
+  });
+}
+
+function updateHistory() {
+  historyLogEl.innerHTML = '';
+  if (!gameState.history.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'chronicle__entry chronicle__entry--empty';
+    placeholder.textContent = 'No spells recorded yet.';
+    historyLogEl.appendChild(placeholder);
+    return;
+  }
+  gameState.history.forEach((entry) => {
+    const item = document.createElement('li');
+    item.className = 'chronicle__entry';
+    if (entry.type === 'spell') {
+      if (!entry.success) {
+        item.classList.add('is-failure');
+      }
+      const expression = document.createElement('div');
+      expression.className = 'chronicle__expression';
+      expression.textContent = entry.expression;
+      item.appendChild(expression);
+
+      const details = document.createElement('div');
+      details.className = 'chronicle__details';
+      if (entry.result !== undefined && entry.result !== null) {
+        const resultSpan = document.createElement('span');
+        resultSpan.textContent = `Result: ${entry.result}`;
+        details.appendChild(resultSpan);
+      }
+      if (entry.message) {
+        const messageSpan = document.createElement('span');
+        messageSpan.textContent = entry.message;
+        details.appendChild(messageSpan);
+      }
+      if (entry.tags && entry.tags.length) {
+        const tagsSpan = document.createElement('span');
+        tagsSpan.textContent = entry.tags.join(' • ');
+        details.appendChild(tagsSpan);
+      }
+      item.appendChild(details);
+    } else {
+      item.classList.add('is-event');
+      const message = document.createElement('div');
+      message.className = 'chronicle__expression';
+      message.textContent = entry.message;
+      item.appendChild(message);
+    }
+    historyLogEl.appendChild(item);
+  });
+}
+
+function penalize(isWrongValue, context = {}) {
+  gameState.streak = 0;
+  gameState.level = Math.max(1, gameState.level - 0.25);
+  const defaultMessage = isWrongValue
+    ? 'The spell fizzled. Match the target exactly.'
+    : 'The glyphs rebelled. Try another structure.';
+  const message = context.message || defaultMessage;
+  setHint(message);
+  if (!context.skipLog) {
+    logSpell({
+      success: false,
+      expression: context.expression ?? gameState.expression,
+      result: context.result,
+      message
+    });
+  }
+  updateStatus();
+  flashMeter('danger');
+  updateArtifacts();
+}
+
+function flashMeter(type) {
+  const className = type === 'danger' ? 'is-danger' : 'is-success';
+  timeMeter.classList.add(className);
+  setTimeout(() => timeMeter.classList.remove(className), 300);
+}
+
+function updateStatus() {
+  scoreEl.textContent = gameState.score;
+  streakEl.textContent = gameState.streak;
+  levelEl.textContent = Math.max(1, Math.floor(gameState.level));
+  stageEl.textContent = gameState.stage;
+}
+
+function updateTimerDisplay() {
+  timerEl.textContent = Math.max(0, Math.ceil(gameState.timeRemaining)).toString();
+  const ratio = Math.max(0, gameState.timeRemaining / gameState.currentTimeLimit);
+  timeMeter.style.transform = `scaleX(${ratio})`;
+}
+
+function resetTimer() {
+  if (gameState.timer) {
+    clearInterval(gameState.timer);
+  }
+  gameState.currentTimeLimit = Math.max(
+    8,
+    gameState.baseTime - gameState.level * 1.5 - gameState.roundCount
+  );
+  gameState.timeRemaining = gameState.currentTimeLimit;
+  updateTimerDisplay();
+  gameState.timer = setInterval(() => {
+    gameState.timeRemaining -= 0.1;
+    if (gameState.timeRemaining <= 0) {
+      clearInterval(gameState.timer);
+      gameState.timer = null;
+      penalize(true, {
+        message: 'Time unraveled before the incantation completed.',
+        expression: gameState.expression
+      });
+      logEncounterEvent('The temporal meter collapsed! The rift surges.');
+      nextChallenge();
+    }
+    updateTimerDisplay();
+  }, 100);
+}
+
+function updateGlyphBank() {
+  glyphBankEl.innerHTML = '';
+  gameState.glyphs.forEach((glyph) => {
+    const li = document.createElement('li');
+    li.textContent = glyph;
+    if (gameState.digitsUsed.has(glyph)) {
+      li.classList.add('used');
+    }
+    glyphBankEl.appendChild(li);
+  });
+}
+
+function updateGlyphUsage() {
+  const items = glyphBankEl.querySelectorAll('li');
+  items.forEach((item) => {
+    const glyph = item.textContent;
+    item.classList.toggle('used', gameState.digitsUsed.has(glyph));
+  });
+}
+
+function setHint(message) {
+  hintEl.textContent = message;
+}
+
+function nextChallenge(advanceRound = true) {
+  if (advanceRound) {
+    gameState.roundCount += 1;
+  }
+  gameState.glyphs = selectGlyphs();
+  gameState.target = craftTarget(gameState.glyphs);
+  gameState.expression = '';
+  gameState.digitsUsed.clear();
+
+  targetEl.textContent = gameState.target;
+  expressionEl.textContent = '\u00A0';
+  updateGlyphBank();
+  assignSigilCondition();
+  setHint('Compose a spell that resolves to the target glyph.');
+  resetTimer();
+}
+
+function selectGlyphs() {
+  const count = Math.min(
+    9,
+    Math.max(
+      3,
+      4 + Math.floor(gameState.level / 2) + Math.floor(Math.max(0, gameState.stage - 1) / 2)
+    )
+  );
+  const pool = [...digits];
+  const chosen = [];
+  for (let i = 0; i < count; i++) {
+    const index = Math.floor(Math.random() * pool.length);
+    chosen.push(pool.splice(index, 1)[0]);
+  }
+  return chosen.sort();
+}
+
+function craftTarget(glyphs) {
+  const sampleDigits = [...glyphs];
+  const opsPool = ['+', '-', '*', '/'];
+  if (gameState.stage >= 3) {
+    opsPool.push('**');
+  }
+  let expression = '';
+  let lastWasOperator = true;
+  const extraLength = Math.min(3, Math.floor(gameState.stage / 2));
+  const length = 3 + Math.floor(Math.random() * (3 + extraLength));
+  for (let i = 0; i < length; i++) {
+    if (lastWasOperator) {
+      const digit = sampleDigits[Math.floor(Math.random() * sampleDigits.length)];
+      expression += digit;
+      lastWasOperator = false;
+    } else {
+      const op = opsPool[Math.floor(Math.random() * opsPool.length)];
+      expression += op;
+      lastWasOperator = true;
+    }
+  }
+  if (lastWasOperator) {
+    expression += sampleDigits[Math.floor(Math.random() * sampleDigits.length)];
+  }
+
+  try {
+    const value = new Function(`return (${expression})`)();
+    const rounded = Math.round(value);
+    return Math.max(-99, Math.min(120, rounded));
+  } catch (error) {
+    return Math.floor(Math.random() * 50) + 10;
+  }
+}
+
+function startGame() {
+  if (gameState.timer) {
+    clearInterval(gameState.timer);
+  }
+  gameState = {
+    active: true,
+    score: 0,
+    streak: 0,
+    level: 1,
+    stage: 1,
+    timer: null,
+    timeRemaining: 0,
+    baseTime: 35,
+    currentTimeLimit: 0,
+    target: null,
+    glyphs: [],
+    expression: '',
+    digitsUsed: new Set(),
+    roundCount: 0,
+    encounter: null,
+    sigilCondition: null,
+    sigilBonus: 0,
+    artifacts: {
+      stabilize: 0,
+      reshuffle: 0
+    },
+    history: []
+  };
+  updateStatus();
+  updateArtifacts();
+  updateHistory();
+  timerEl.textContent = '--';
+  setHint('The codex hums with possibility.');
+  logEncounterEvent('A new ritual begins.');
+  setupEncounter();
+  nextChallenge();
+  startButton.textContent = 'Restart Ritual';
+}
+
+startButton.addEventListener('click', () => {
+  startGame();
+});
+
+initKeyboard();
+initArtifacts();
+updateHistory();
+setHint('Ready when you are. Tap Start Casting to begin.');

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,456 @@
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at top, #221933 0%, #0f0b18 60%, #05030a 100%);
+  --panel: rgba(27, 20, 38, 0.7);
+  --accent: #ff9d3b;
+  --accent-strong: #ffb953;
+  --text: #f2f2f7;
+  --muted: #b1a7c2;
+  --danger: #ff5c5c;
+  font-family: 'Kanit', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: clamp(16px, 3vw, 32px);
+}
+
+main.app {
+  width: min(1100px, 100%);
+  display: grid;
+  gap: clamp(16px, 2vw, 24px);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-auto-rows: minmax(120px, auto);
+}
+
+.app__header {
+  grid-column: 1 / -1;
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 20px;
+  padding: clamp(16px, 3vw, 24px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  backdrop-filter: blur(12px);
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 42px);
+  letter-spacing: 0.05em;
+}
+
+.branding p {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.button {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 12px 18px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease,
+    background-color 120ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(255, 157, 59, 0.25);
+  outline: none;
+}
+
+.button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #1b1426;
+  border: none;
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: var(--text);
+}
+
+.status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 12px;
+  background: var(--panel);
+  border-radius: 20px;
+  padding: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.status__item {
+  display: grid;
+  gap: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  padding: 12px 16px;
+}
+
+.status__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.status__value {
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 700;
+}
+
+.battlefield {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 12px;
+  background: var(--panel);
+  border-radius: 20px;
+  padding: clamp(16px, 3vw, 24px);
+}
+
+.encounter {
+  grid-column: 1 / -1;
+  background: var(--panel);
+  border-radius: 20px;
+  padding: clamp(16px, 3vw, 24px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 16px;
+}
+
+.encounter__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.encounter__stage {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.encounter__narrative {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.encounter__health {
+  display: grid;
+  gap: 8px;
+}
+
+.encounter__bar {
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  position: relative;
+}
+
+.encounter__fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #70ffba, #2dd5ff);
+  transform-origin: left center;
+  transition: transform 200ms ease;
+}
+
+.encounter__hp {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.encounter__objective h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.encounter__objective p {
+  margin: 6px 0 0;
+  line-height: 1.5;
+}
+
+.encounter__bonus {
+  color: var(--accent-strong);
+}
+
+.challenge {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.challenge__prompt {
+  font-size: 0.9rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.challenge__value {
+  margin-top: 6px;
+  font-size: clamp(2rem, 6vw, 3rem);
+  font-weight: 700;
+}
+
+.challenge--glyphs .challenge__value {
+  font-size: 1.5rem;
+}
+
+.glyphs {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 0 0;
+  margin: 0;
+}
+
+.glyphs li {
+  min-width: 46px;
+  text-align: center;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: border 120ms ease, transform 120ms ease;
+}
+
+.glyphs li.used {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.meter {
+  position: relative;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.meter__fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  width: 100%;
+  transform-origin: left center;
+  transition: transform 120ms linear, background 160ms ease;
+}
+
+.meter__fill.is-danger {
+  background: linear-gradient(90deg, #ff5c5c, #ff915c);
+}
+
+.meter__fill.is-success {
+  background: linear-gradient(90deg, #70ffba, #2dd5ff);
+}
+
+.meter__label {
+  margin-top: 12px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.workspace {
+  display: grid;
+  gap: 16px;
+  background: var(--panel);
+  border-radius: 20px;
+  padding: clamp(16px, 3vw, 24px);
+  grid-column: span 2;
+  min-height: min(420px, 50vh);
+}
+
+.workspace__display {
+  min-height: 64px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 16px;
+  font-size: clamp(1.4rem, 4vw, 2.4rem);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.keyboard {
+  display: grid;
+  gap: 12px;
+}
+
+.keyboard__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(52px, 1fr));
+  gap: 10px;
+}
+
+.keyboard button {
+  padding: 14px 10px;
+  font-size: 1.1rem;
+}
+
+.keyboard__row--controls {
+  grid-template-columns: repeat(3, minmax(90px, 1fr));
+}
+
+.artifacts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.workspace__hint {
+  min-height: 24px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.chronicle {
+  background: var(--panel);
+  border-radius: 20px;
+  padding: clamp(16px, 3vw, 24px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 12px;
+}
+
+.chronicle h2 {
+  margin: 0;
+}
+
+.chronicle__log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.chronicle__entry {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 14px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: grid;
+  gap: 6px;
+}
+
+.chronicle__entry.is-failure {
+  border-color: rgba(255, 92, 92, 0.6);
+}
+
+.chronicle__entry.is-event {
+  border-color: rgba(112, 255, 186, 0.6);
+}
+
+.chronicle__entry--empty {
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.12);
+  text-align: center;
+  color: var(--muted);
+}
+
+.chronicle__expression {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.chronicle__details {
+  color: var(--muted);
+  font-size: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.codex {
+  background: var(--panel);
+  border-radius: 20px;
+  padding: clamp(16px, 3vw, 24px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.codex h2 {
+  margin-top: 0;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+}
+
+.codex ol {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.codex__tip {
+  margin-top: 16px;
+  font-size: 0.95rem;
+  color: var(--accent-strong);
+}
+
+@media (max-width: 900px) {
+  main.app {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace {
+    grid-column: 1 / -1;
+    min-height: min(360px, 55vh);
+  }
+
+  .artifacts {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+  }
+
+  .workspace__display {
+    min-height: 72px;
+  }
+
+  .keyboard__row--controls {
+    grid-template-columns: repeat(3, minmax(80px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- add encounter panel with stage tracking, stability meter, sigil condition callouts, and artifact controls
- implement stage progression, sigil objectives, artifact abilities, and spell chronicle logging in gameplay logic
- refresh styling and README to cover the expanded encounters, artifacts, and history systems

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68e1d9640d10832fa59c265c7d38ba5e